### PR TITLE
Add rooms listing page with modal

### DIFF
--- a/src/app/hotels/[hotelId]/rooms/AddRoomModal.tsx
+++ b/src/app/hotels/[hotelId]/rooms/AddRoomModal.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { useState } from 'react'
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField, Stack } from '@mui/material'
+import { useRouter } from 'next/navigation'
+
+type Props = { hotelId: string }
+
+export default function AddRoomModal({ hotelId }: Props) {
+  const [open, setOpen] = useState(false)
+  const [name, setName] = useState('')
+  const [type, setType] = useState('')
+  const [capacity, setCapacity] = useState(1)
+  const router = useRouter()
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    await fetch(`/api/hotels/${hotelId}/rooms`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, type, capacity: Number(capacity) }),
+    })
+    setOpen(false)
+    router.refresh()
+    setName('')
+    setType('')
+    setCapacity(1)
+  }
+
+  return (
+    <>
+      <Button variant="contained" onClick={() => setOpen(true)}>
+        Add Room
+      </Button>
+      <Dialog open={open} onClose={() => setOpen(false)}>
+        <DialogTitle>Add Room</DialogTitle>
+        <form onSubmit={handleSubmit}>
+          <DialogContent>
+            <Stack spacing={2} sx={{ mt: 1, minWidth: 300 }}>
+              <TextField label="Name" value={name} onChange={e => setName(e.target.value)} required fullWidth />
+              <TextField label="Type" value={type} onChange={e => setType(e.target.value)} required fullWidth />
+              <TextField label="Capacity" type="number" value={capacity} onChange={e => setCapacity(parseInt(e.target.value, 10))} required fullWidth inputProps={{ min: 1 }} />
+            </Stack>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setOpen(false)}>Cancel</Button>
+            <Button type="submit" variant="contained">Save</Button>
+          </DialogActions>
+        </form>
+      </Dialog>
+    </>
+  )
+}

--- a/src/app/hotels/[hotelId]/rooms/RoomsTable.tsx
+++ b/src/app/hotels/[hotelId]/rooms/RoomsTable.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { DataGrid, GridColDef } from '@mui/x-data-grid'
+
+export type Room = {
+  _id: string
+  name: string
+  type: string
+  capacity: number
+}
+
+export default function RoomsTable({ rooms }: { rooms: Room[] }) {
+  const columns: GridColDef[] = [
+    { field: 'name', headerName: 'Name', flex: 1 },
+    { field: 'type', headerName: 'Type', flex: 1 },
+    { field: 'capacity', headerName: 'Capacity', type: 'number', flex: 1 },
+  ]
+
+  const rows = rooms.map((room) => ({ id: room._id, ...room }))
+
+  return <DataGrid rows={rows} columns={columns} autoHeight />
+}

--- a/src/app/hotels/[hotelId]/rooms/page.tsx
+++ b/src/app/hotels/[hotelId]/rooms/page.tsx
@@ -1,0 +1,20 @@
+import AddRoomModal from './AddRoomModal'
+import RoomsTable, { Room } from './RoomsTable'
+
+interface Params {
+  params: { hotelId: string }
+}
+
+export default async function RoomsPage({ params }: Params) {
+  const res = await fetch(`http://localhost:3000/api/hotels/${params.hotelId}/rooms`, { cache: 'no-store' })
+  const rooms: Room[] = await res.json()
+
+  return (
+    <div style={{ padding: '16px' }}>
+      <AddRoomModal hotelId={params.hotelId} />
+      <div style={{ marginTop: '16px' }}>
+        <RoomsTable rooms={rooms} />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add rooms page for hotels with server-side fetching
- list rooms in MUI DataGrid
- include AddRoomModal client component for creating rooms

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ba9964f048331ba1aa2f09e78ea29