### PR TITLE
Add Room Modal props refactor

### DIFF
--- a/src/app/hotels/[hotelId]/rooms/AddRoomModal.tsx
+++ b/src/app/hotels/[hotelId]/rooms/AddRoomModal.tsx
@@ -1,53 +1,93 @@
-'use client'
+"use client"
 
-import { useState } from 'react'
-import { Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField, Stack } from '@mui/material'
-import { useRouter } from 'next/navigation'
+import { useState } from "react"
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  Stack,
+} from "@mui/material"
 
-type Props = { hotelId: string }
+type Props = {
+  hotelId: string
+  open: boolean
+  onClose: () => void
+  onSuccess: () => void
+}
 
-export default function AddRoomModal({ hotelId }: Props) {
-  const [open, setOpen] = useState(false)
-  const [name, setName] = useState('')
-  const [type, setType] = useState('')
-  const [capacity, setCapacity] = useState(1)
-  const router = useRouter()
+export default function AddRoomModal({
+  hotelId,
+  open,
+  onClose,
+  onSuccess,
+}: Props) {
+  const [name, setName] = useState("")
+  const [type, setType] = useState("")
+  const [capacity, setCapacity] = useState("")
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
+
+    const parsedCapacity = Number(capacity)
+    if (!name || !type || Number.isNaN(parsedCapacity)) {
+      return
+    }
+
     await fetch(`/api/hotels/${hotelId}/rooms`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, type, capacity: Number(capacity) }),
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, type, capacity: parsedCapacity }),
     })
-    setOpen(false)
-    router.refresh()
-    setName('')
-    setType('')
-    setCapacity(1)
+
+    onSuccess()
+    onClose()
+
+    setName("")
+    setType("")
+    setCapacity("")
   }
 
   return (
-    <>
-      <Button variant="contained" onClick={() => setOpen(true)}>
-        Add Room
-      </Button>
-      <Dialog open={open} onClose={() => setOpen(false)}>
-        <DialogTitle>Add Room</DialogTitle>
-        <form onSubmit={handleSubmit}>
-          <DialogContent>
-            <Stack spacing={2} sx={{ mt: 1, minWidth: 300 }}>
-              <TextField label="Name" value={name} onChange={e => setName(e.target.value)} required fullWidth />
-              <TextField label="Type" value={type} onChange={e => setType(e.target.value)} required fullWidth />
-              <TextField label="Capacity" type="number" value={capacity} onChange={e => setCapacity(parseInt(e.target.value, 10))} required fullWidth inputProps={{ min: 1 }} />
-            </Stack>
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setOpen(false)}>Cancel</Button>
-            <Button type="submit" variant="contained">Save</Button>
-          </DialogActions>
-        </form>
-      </Dialog>
-    </>
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>Add Room</DialogTitle>
+      <form onSubmit={handleSubmit}>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1, minWidth: 300 }}>
+            <TextField
+              label="Name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              fullWidth
+            />
+            <TextField
+              label="Type"
+              value={type}
+              onChange={(e) => setType(e.target.value)}
+              required
+              fullWidth
+            />
+            <TextField
+              label="Capacity"
+              type="number"
+              value={capacity}
+              onChange={(e) => setCapacity(e.target.value)}
+              required
+              fullWidth
+              inputProps={{ min: 1 }}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose}>Cancel</Button>
+          <Button type="submit" variant="contained">
+            Save
+          </Button>
+        </DialogActions>
+      </form>
+    </Dialog>
   )
 }

--- a/src/app/hotels/[hotelId]/rooms/RoomsPageClient.tsx
+++ b/src/app/hotels/[hotelId]/rooms/RoomsPageClient.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@mui/material'
+import AddRoomModal from './AddRoomModal'
+import RoomsTable, { type Room } from './RoomsTable'
+import { useRouter } from 'next/navigation'
+
+interface Props {
+  hotelId: string
+  rooms: Room[]
+}
+
+export default function RoomsPageClient({ hotelId, rooms }: Props) {
+  const [open, setOpen] = useState(false)
+  const router = useRouter()
+
+  const handleSuccess = () => {
+    router.refresh()
+  }
+
+  return (
+    <div style={{ padding: '16px' }}>
+      <Button variant="contained" onClick={() => setOpen(true)}>
+        Add Room
+      </Button>
+      <AddRoomModal
+        hotelId={hotelId}
+        open={open}
+        onClose={() => setOpen(false)}
+        onSuccess={handleSuccess}
+      />
+      <div style={{ marginTop: '16px' }}>
+        <RoomsTable rooms={rooms} />
+      </div>
+    </div>
+  )
+}

--- a/src/app/hotels/[hotelId]/rooms/page.tsx
+++ b/src/app/hotels/[hotelId]/rooms/page.tsx
@@ -1,20 +1,16 @@
-import AddRoomModal from './AddRoomModal'
-import RoomsTable, { Room } from './RoomsTable'
+import RoomsPageClient from './RoomsPageClient'
+import { Room } from './RoomsTable'
 
 interface Params {
   params: { hotelId: string }
 }
 
 export default async function RoomsPage({ params }: Params) {
-  const res = await fetch(`http://localhost:3000/api/hotels/${params.hotelId}/rooms`, { cache: 'no-store' })
+  const res = await fetch(
+    `http://localhost:3000/api/hotels/${params.hotelId}/rooms`,
+    { cache: 'no-store' }
+  )
   const rooms: Room[] = await res.json()
 
-  return (
-    <div style={{ padding: '16px' }}>
-      <AddRoomModal hotelId={params.hotelId} />
-      <div style={{ marginTop: '16px' }}>
-        <RoomsTable rooms={rooms} />
-      </div>
-    </div>
-  )
+  return <RoomsPageClient hotelId={params.hotelId} rooms={rooms} />
 }


### PR DESCRIPTION
## Summary
- refactor `AddRoomModal` to accept open/close callbacks
- add new `RoomsPageClient` wrapper
- update rooms page to use the client wrapper

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685bac567b1083319e22b3e067e1caf5