### PR TITLE
Add room delete column

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@mui/material": "^7.1.2",
+        "@mui/icons-material": "^5.11.16",
         "@mui/x-data-grid": "^8.5.3",
         "mongodb": "^6.17.0",
         "next": "15.3.4",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@mui/material": "^7.1.2",
+    "@mui/icons-material": "^5.11.16",
     "@mui/x-data-grid": "^8.5.3",
     "mongodb": "^6.17.0",
     "next": "15.3.4",

--- a/src/app/hotels/[hotelId]/rooms/RoomsPageClient.tsx
+++ b/src/app/hotels/[hotelId]/rooms/RoomsPageClient.tsx
@@ -3,20 +3,18 @@
 import { useState } from 'react'
 import { Button } from '@mui/material'
 import AddRoomModal from './AddRoomModal'
-import RoomsTable, { type Room } from './RoomsTable'
-import { useRouter } from 'next/navigation'
+import RoomsTable from './RoomsTable'
 
 interface Props {
   hotelId: string
-  rooms: Room[]
 }
 
-export default function RoomsPageClient({ hotelId, rooms }: Props) {
+export default function RoomsPageClient({ hotelId }: Props) {
   const [open, setOpen] = useState(false)
-  const router = useRouter()
+  const [refreshTrigger, setRefreshTrigger] = useState(0)
 
   const handleSuccess = () => {
-    router.refresh()
+    setRefreshTrigger((prev) => prev + 1)
   }
 
   return (
@@ -31,7 +29,11 @@ export default function RoomsPageClient({ hotelId, rooms }: Props) {
         onSuccess={handleSuccess}
       />
       <div style={{ marginTop: '16px' }}>
-        <RoomsTable rooms={rooms} />
+        <RoomsTable
+          hotelId={hotelId}
+          refreshTrigger={refreshTrigger}
+          onDeleteSuccess={handleSuccess}
+        />
       </div>
     </div>
   )

--- a/src/app/hotels/[hotelId]/rooms/RoomsTable.tsx
+++ b/src/app/hotels/[hotelId]/rooms/RoomsTable.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useState } from 'react'
 import { DataGrid, GridColDef } from '@mui/x-data-grid'
+import { IconButton } from '@mui/material'
+import DeleteIcon from '@mui/icons-material/Delete'
 
 export type Room = {
   _id: string
@@ -13,9 +15,10 @@ export type Room = {
 interface Props {
   hotelId: string
   refreshTrigger?: unknown
+  onDeleteSuccess: () => void
 }
 
-export default function RoomsTable({ hotelId, refreshTrigger }: Props) {
+export default function RoomsTable({ hotelId, refreshTrigger, onDeleteSuccess }: Props) {
   const [rooms, setRooms] = useState<Room[]>([])
   const [loading, setLoading] = useState<boolean>(true)
 
@@ -44,10 +47,30 @@ export default function RoomsTable({ hotelId, refreshTrigger }: Props) {
     }
   }, [hotelId, refreshTrigger])
 
+  const handleDelete = async (roomId: string) => {
+    await fetch(`/api/hotels/${hotelId}/rooms/${roomId}`, { method: 'DELETE' })
+    onDeleteSuccess()
+  }
+
   const columns: GridColDef[] = [
     { field: 'name', headerName: 'Name', flex: 1 },
     { field: 'type', headerName: 'Type', flex: 1 },
     { field: 'capacity', headerName: 'Capacity', type: 'number', flex: 1 },
+    {
+      field: 'actions',
+      headerName: '',
+      sortable: false,
+      renderCell: (params) => (
+        <IconButton
+          aria-label="delete"
+          color="error"
+          onClick={() => handleDelete(params.row.id as string)}
+        >
+          <DeleteIcon />
+        </IconButton>
+      ),
+      width: 80,
+    },
   ]
 
   const rows = rooms.map((room) => ({ id: room._id, ...room }))

--- a/src/app/hotels/[hotelId]/rooms/page.tsx
+++ b/src/app/hotels/[hotelId]/rooms/page.tsx
@@ -1,16 +1,9 @@
 import RoomsPageClient from './RoomsPageClient'
-import { Room } from './RoomsTable'
 
 interface Params {
   params: { hotelId: string }
 }
 
 export default async function RoomsPage({ params }: Params) {
-  const res = await fetch(
-    `http://localhost:3000/api/hotels/${params.hotelId}/rooms`,
-    { cache: 'no-store' }
-  )
-  const rooms: Room[] = await res.json()
-
-  return <RoomsPageClient hotelId={params.hotelId} rooms={rooms} />
+  return <RoomsPageClient hotelId={params.hotelId} />
 }


### PR DESCRIPTION
## Summary
- allow refreshing rooms table client-side
- hook up deletion to API via a new column in RoomsTable
- simplify `/rooms` page server component
- add `@mui/icons-material` dependency for delete icon

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb314bc48833191bd7ddac0adac91