### PR TITLE
Add search filter for rooms

### DIFF
--- a/src/app/hotels/[hotelId]/rooms/RoomsPageClient.tsx
+++ b/src/app/hotels/[hotelId]/rooms/RoomsPageClient.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Button } from '@mui/material'
+import { Button, TextField } from '@mui/material'
 import AddRoomModal from './AddRoomModal'
 import RoomsTable from './RoomsTable'
 
@@ -12,6 +12,7 @@ interface Props {
 export default function RoomsPageClient({ hotelId }: Props) {
   const [open, setOpen] = useState(false)
   const [refreshTrigger, setRefreshTrigger] = useState(0)
+  const [search, setSearch] = useState('')
 
   const handleSuccess = () => {
     setRefreshTrigger((prev) => prev + 1)
@@ -19,9 +20,17 @@ export default function RoomsPageClient({ hotelId }: Props) {
 
   return (
     <div style={{ padding: '16px' }}>
-      <Button variant="contained" onClick={() => setOpen(true)}>
-        Add Room
-      </Button>
+      <div style={{ display: 'flex', gap: '16px', alignItems: 'center' }}>
+        <Button variant="contained" onClick={() => setOpen(true)}>
+          Add Room
+        </Button>
+        <TextField
+          label="Search rooms"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          size="small"
+        />
+      </div>
       <AddRoomModal
         hotelId={hotelId}
         open={open}
@@ -33,6 +42,7 @@ export default function RoomsPageClient({ hotelId }: Props) {
           hotelId={hotelId}
           refreshTrigger={refreshTrigger}
           onDeleteSuccess={handleSuccess}
+          search={search}
         />
       </div>
     </div>

--- a/src/app/hotels/[hotelId]/rooms/RoomsTable.tsx
+++ b/src/app/hotels/[hotelId]/rooms/RoomsTable.tsx
@@ -16,9 +16,15 @@ interface Props {
   hotelId: string
   refreshTrigger?: unknown
   onDeleteSuccess: () => void
+  search?: string
 }
 
-export default function RoomsTable({ hotelId, refreshTrigger, onDeleteSuccess }: Props) {
+export default function RoomsTable({
+  hotelId,
+  refreshTrigger,
+  onDeleteSuccess,
+  search = '',
+}: Props) {
   const [rooms, setRooms] = useState<Room[]>([])
   const [loading, setLoading] = useState<boolean>(true)
 
@@ -73,7 +79,15 @@ export default function RoomsTable({ hotelId, refreshTrigger, onDeleteSuccess }:
     },
   ]
 
-  const rows = rooms.map((room) => ({ id: room._id, ...room }))
+  const filteredRooms = rooms.filter((room) => {
+    const query = search.toLowerCase()
+    return (
+      room.name.toLowerCase().includes(query) ||
+      room.type.toLowerCase().includes(query)
+    )
+  })
+
+  const rows = filteredRooms.map((room) => ({ id: room._id, ...room }))
 
   return <DataGrid rows={rows} columns={columns} loading={loading} autoHeight />
 }


### PR DESCRIPTION
## Summary
- add search field to rooms page
- filter rooms on client-side based on search query

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb7b4e5a8833193292883237d9c6e